### PR TITLE
CY-2608-Upgrade-Wagon-On-PY27

### DIFF
--- a/centos_6/Dockerfile
+++ b/centos_6/Dockerfile
@@ -45,7 +45,7 @@ RUN cd / && \
     source env/bin/activate && \
     pip install --upgrade pip==9.0.1 && \
     pip install --upgrade virtualenv==15.1.0 && \
-    pip install wagon==0.3.2
+    pip install wagon==0.6.3
 
 
 WORKDIR /packaging

--- a/centos_6/cloudify-wagon-builder.sh
+++ b/centos_6/cloudify-wagon-builder.sh
@@ -3,6 +3,7 @@ set -e
 echo "Starting..."
 
 CONSTRAINTS_FILE=/packaging/constraints.txt
+REQUIRMENTS_FILE=/packaging/dev-requirements.txt
 
 if test -f /packaging/extra-packaging-instructions.sh
 then
@@ -13,10 +14,15 @@ echo "manylinux1_compatible = False" > "/env/bin/_manylinux.py"
 if test -f ${CONSTRAINTS_FILE}
 then
     echo "## $CONSTRAINTS_FILE exist"
-    wagon create -s . -r -v -f -a '--no-cache-dir -c '${CONSTRAINTS_FILE}''
+    wagon create -r ${REQUIRMENTS_FILE} -v -f -a '--no-cache-dir -c '${CONSTRAINTS_FILE}'' .
 else
     echo "## $CONSTRAINTS_FILE doesn't exist"
-    wagon create -s . -r -v -f
+    wagon create -r ${REQUIRMENTS_FILE} -v -f .
 fi
+
+echo "appending platform to wagon file name"
+OS_DIST=$(python -c 'import platform; print(platform.linux_distribution(full_distribution_name=False)[0])')
+OS_RELEASE=$(python -c 'import platform; print(platform.linux_distribution(full_distribution_name=False)[2])')
+ls /packaging/*.wgn | sed 'p;s/\.wgn/\-'${OS_DIST}'-'${OS_RELEASE}'.wgn/' | xargs -n2 mv
 
 cp -R * /workspace/build/

--- a/centos_7/Dockerfile
+++ b/centos_7/Dockerfile
@@ -14,7 +14,7 @@ RUN cd / && \
     source env/bin/activate && \
     pip install --upgrade pip==9.0.1 && \
     pip install --upgrade virtualenv==15.1.0 && \
-    pip install wagon==0.3.2
+    pip install wagon==0.6.3
 
 
 WORKDIR /packaging

--- a/centos_7/cloudify-wagon-builder.sh
+++ b/centos_7/cloudify-wagon-builder.sh
@@ -3,6 +3,7 @@ set -e
 echo "Starting..."
 
 CONSTRAINTS_FILE=/packaging/constraints.txt
+REQUIRMENTS_FILE=/packaging/dev-requirements.txt
 
 if test -f /packaging/extra-packaging-instructions.sh
 then
@@ -13,10 +14,15 @@ echo "manylinux1_compatible = False" > "/env/bin/_manylinux.py"
 if test -f ${CONSTRAINTS_FILE}
 then
     echo "## $CONSTRAINTS_FILE exist"
-    wagon create -s . -r -v -f -a '--no-cache-dir -c '${CONSTRAINTS_FILE}''
+    wagon create -r ${REQUIRMENTS_FILE} -v -f -a '--no-cache-dir -c '${CONSTRAINTS_FILE}'' .
 else
     echo "## $CONSTRAINTS_FILE doesn't exist"
-    wagon create -s . -r -v -f
+    wagon create -r ${REQUIRMENTS_FILE} -v -f .
 fi
+
+echo "appending platform to wagon file name"
+OS_DIST=$(python -c 'import platform; print(platform.linux_distribution(full_distribution_name=False)[0])')
+OS_RELEASE=$(python -c 'import platform; print(platform.linux_distribution(full_distribution_name=False)[2])')
+ls /packaging/*.wgn | sed 'p;s/\.wgn/\-'${OS_DIST}'-'${OS_RELEASE}'.wgn/' | xargs -n2 mv
 
 cp -R * /workspace/build/

--- a/redhat_7/Dockerfile
+++ b/redhat_7/Dockerfile
@@ -22,7 +22,7 @@ RUN cd / && \
     source env/bin/activate && \
     pip install --upgrade pip==9.0.1 && \
     pip install --upgrade virtualenv==15.1.0 && \
-    pip install wagon==0.3.2
+    pip install wagon==0.6.3
 
 
 RUN subscription-manager unregister

--- a/redhat_7/cloudify-wagon-builder.sh
+++ b/redhat_7/cloudify-wagon-builder.sh
@@ -3,6 +3,7 @@ set -e
 echo "Starting..."
 
 CONSTRAINTS_FILE=/packaging/constraints.txt
+REQUIRMENTS_FILE=/packaging/dev-requirements.txt
 
 if test -f /packaging/extra-packaging-instructions.sh
 then
@@ -13,10 +14,15 @@ echo "manylinux1_compatible = False" > "/env/bin/_manylinux.py"
 if test -f ${CONSTRAINTS_FILE}
 then
     echo "## $CONSTRAINTS_FILE exist"
-    wagon create -s . -r -v -f -a '--no-cache-dir -c '${CONSTRAINTS_FILE}''
+    wagon create -r ${REQUIRMENTS_FILE} -v -f -a '--no-cache-dir -c '${CONSTRAINTS_FILE}'' .
 else
     echo "## $CONSTRAINTS_FILE doesn't exist"
-    wagon create -s . -r -v -f
+    wagon create -r ${REQUIRMENTS_FILE} -v -f .
 fi
+
+echo "appending platform to wagon file name"
+OS_DIST=$(python -c 'import platform; print(platform.linux_distribution(full_distribution_name=False)[0])')
+OS_RELEASE=$(python -c 'import platform; print(platform.linux_distribution(full_distribution_name=False)[2])')
+ls /packaging/*.wgn | sed 'p;s/\.wgn/\-'${OS_DIST}'-'${OS_RELEASE}'.wgn/' | xargs -n2 mv
 
 cp -R * /workspace/build/

--- a/ubuntu_12_04/Dockerfile
+++ b/ubuntu_12_04/Dockerfile
@@ -19,7 +19,7 @@ RUN cd / && \
     /bin/bash -c "source env/bin/activate" && \
     pip install --upgrade pip==9.0.1 && \
     pip install --upgrade virtualenv==15.1.0 && \
-    pip install wagon==0.3.2
+    pip install wagon==0.6.3
 
 
 WORKDIR /packaging

--- a/ubuntu_12_04/cloudify-wagon-builder.sh
+++ b/ubuntu_12_04/cloudify-wagon-builder.sh
@@ -3,6 +3,7 @@ set -e
 echo "Starting..."
 
 CONSTRAINTS_FILE=/packaging/constraints.txt
+REQUIRMENTS_FILE=/packaging/dev-requirements.txt
 
 if test -f /packaging/extra-packaging-instructions.sh
 then
@@ -13,10 +14,15 @@ echo "manylinux1_compatible = False" > "/env/bin/_manylinux.py"
 if test -f ${CONSTRAINTS_FILE}
 then
     echo "## $CONSTRAINTS_FILE exist"
-    wagon create -s . -r -v -f -a '--no-cache-dir -c '${CONSTRAINTS_FILE}''
+    wagon create -r ${REQUIRMENTS_FILE} -v -f -a '--no-cache-dir -c '${CONSTRAINTS_FILE}'' .
 else
     echo "## $CONSTRAINTS_FILE doesn't exist"
-    wagon create -s . -r -v -f
+    wagon create -r ${REQUIRMENTS_FILE} -v -f .
 fi
+
+echo "appending platform to wagon file name"
+OS_DIST=$(python -c 'import platform; print(platform.linux_distribution(full_distribution_name=False)[0])')
+OS_RELEASE=$(python -c 'import platform; print(platform.linux_distribution(full_distribution_name=False)[2])')
+ls /packaging/*.wgn | sed 'p;s/\.wgn/\-'${OS_DIST}'-'${OS_RELEASE}'.wgn/' | xargs -n2 mv
 
 cp -R * /workspace/build/

--- a/ubuntu_14_04/Dockerfile
+++ b/ubuntu_14_04/Dockerfile
@@ -18,7 +18,7 @@ RUN cd / && \
     /bin/bash -c "source env/bin/activate" && \
     pip install --upgrade pip==9.0.1 && \
     pip install --upgrade virtualenv==15.1.0 && \
-    pip install wagon==0.3.2
+    pip install wagon==0.6.3
 
 WORKDIR /packaging
 

--- a/ubuntu_14_04/cloudify-wagon-builder.sh
+++ b/ubuntu_14_04/cloudify-wagon-builder.sh
@@ -3,6 +3,7 @@ set -e
 echo "Starting..."
 
 CONSTRAINTS_FILE=/packaging/constraints.txt
+REQUIRMENTS_FILE=/packaging/dev-requirements.txt
 
 if test -f /packaging/extra-packaging-instructions.sh
 then
@@ -13,10 +14,15 @@ echo "manylinux1_compatible = False" > "/env/bin/_manylinux.py"
 if test -f ${CONSTRAINTS_FILE}
 then
     echo "## $CONSTRAINTS_FILE exist"
-    wagon create -s . -r -v -f -a '--no-cache-dir -c '${CONSTRAINTS_FILE}''
+    wagon create -r ${REQUIRMENTS_FILE} -v -f -a '--no-cache-dir -c '${CONSTRAINTS_FILE}'' .
 else
     echo "## $CONSTRAINTS_FILE doesn't exist"
-    wagon create -s . -r -v -f
+    wagon create -r ${REQUIRMENTS_FILE} -v -f .
 fi
+
+echo "appending platform to wagon file name"
+OS_DIST=$(python -c 'import platform; print(platform.linux_distribution(full_distribution_name=False)[0])')
+OS_RELEASE=$(python -c 'import platform; print(platform.linux_distribution(full_distribution_name=False)[2])')
+ls /packaging/*.wgn | sed 'p;s/\.wgn/\-'${OS_DIST}'-'${OS_RELEASE}'.wgn/' | xargs -n2 mv
 
 cp -R * /workspace/build/


### PR DESCRIPTION
Upgrade wagon on python 2.7 containers to `0.6.3` and handle the changes in the wagon command and the naming convention 