### PR TITLE
Fix-Py3-Builders

### DIFF
--- a/centos_6_py3/Dockerfile
+++ b/centos_6_py3/Dockerfile
@@ -45,7 +45,7 @@ RUN cd / && \
     source env/bin/activate && \
     pip3 install --upgrade pip==9.0.1 && \
     pip3 install --upgrade virtualenv==15.1.0 && \
-    pip3 install wagon==0.6.3
+    pip3 install wagon==0.9
 
 
 WORKDIR /packaging

--- a/centos_6_py3/cloudify-wagon-builder.sh
+++ b/centos_6_py3/cloudify-wagon-builder.sh
@@ -20,9 +20,4 @@ else
     wagon create -r ${REQUIRMENTS_FILE} -v -f .
 fi
 
-echo "appending platform to wagon file name"
-OS_DIST=$(python -c 'import platform; print(platform.linux_distribution(full_distribution_name=False)[0])')
-OS_RELEASE=$(python -c 'import platform; print(platform.linux_distribution(full_distribution_name=False)[2])')
-ls /packaging/*.wgn | sed 'p;s/\.wgn/\-'${OS_DIST}'-'${OS_RELEASE}'.wgn/' | xargs -n2 mv
-
 cp -R * /workspace/build/

--- a/centos_7_py3/Dockerfile
+++ b/centos_7_py3/Dockerfile
@@ -16,7 +16,7 @@ RUN cd / && \
     source env/bin/activate && \
     pip3 install --upgrade pip==9.0.1 && \
     pip3 install --upgrade virtualenv==15.1.0 && \
-    pip3 install wagon==0.6.3
+    pip3 install wagon==0.9
 
 
 WORKDIR /packaging

--- a/centos_7_py3/cloudify-wagon-builder.sh
+++ b/centos_7_py3/cloudify-wagon-builder.sh
@@ -20,9 +20,4 @@ else
     wagon create -r ${REQUIRMENTS_FILE} -v -f .
 fi
 
-echo "appending platform to wagon file name"
-OS_DIST=$(python -c 'import platform; print(platform.linux_distribution(full_distribution_name=False)[0])')
-OS_RELEASE=$(python -c 'import platform; print(platform.linux_distribution(full_distribution_name=False)[2])')
-ls /packaging/*.wgn | sed 'p;s/\.wgn/\-'${OS_DIST}'-'${OS_RELEASE}'.wgn/' | xargs -n2 mv
-
 cp -R * /workspace/build/

--- a/redhat_7_py3/Dockerfile
+++ b/redhat_7_py3/Dockerfile
@@ -26,7 +26,7 @@ RUN cd / && \
     source env/bin/activate && \
     pip3 install --upgrade pip==9.0.1 && \
     pip3 install --upgrade virtualenv==15.1.0 && \
-    pip3 install wagon==0.6.3
+    pip3 install wagon==0.9
 
 
 RUN subscription-manager unregister

--- a/redhat_7_py3/cloudify-wagon-builder.sh
+++ b/redhat_7_py3/cloudify-wagon-builder.sh
@@ -20,9 +20,4 @@ else
     wagon create -r ${REQUIRMENTS_FILE} -v -f .
 fi
 
-echo "appending platform to wagon file name"
-OS_DIST=$(python -c 'import platform; print(platform.linux_distribution(full_distribution_name=False)[0])')
-OS_RELEASE=$(python -c 'import platform; print(platform.linux_distribution(full_distribution_name=False)[2])')
-ls /packaging/*.wgn | sed 'p;s/\.wgn/\-'${OS_DIST}'-'${OS_RELEASE}'.wgn/' | xargs -n2 mv
-
 cp -R * /workspace/build/

--- a/ubuntu_12_04_py3/Dockerfile
+++ b/ubuntu_12_04_py3/Dockerfile
@@ -29,7 +29,7 @@ RUN cd / && \
     /bin/bash -c "source env/bin/activate" && \
     pip3 install --upgrade pip==9.0.1 && \
     pip3 install --upgrade virtualenv==15.1.0 && \
-    pip3 install wagon==0.6.3
+    pip3 install wagon==0.9
 
 
 WORKDIR /packaging

--- a/ubuntu_12_04_py3/cloudify-wagon-builder.sh
+++ b/ubuntu_12_04_py3/cloudify-wagon-builder.sh
@@ -20,9 +20,4 @@ else
     wagon create -r ${REQUIRMENTS_FILE} -v -f .
 fi
 
-echo "appending platform to wagon file name"
-OS_DIST=$(python -c 'import platform; print(platform.linux_distribution(full_distribution_name=False)[0])')
-OS_RELEASE=$(python -c 'import platform; print(platform.linux_distribution(full_distribution_name=False)[2])')
-ls /packaging/*.wgn | sed 'p;s/\.wgn/\-'${OS_DIST}'-'${OS_RELEASE}'.wgn/' | xargs -n2 mv
-
 cp -R * /workspace/build/

--- a/ubuntu_14_04_py3/Dockerfile
+++ b/ubuntu_14_04_py3/Dockerfile
@@ -29,7 +29,7 @@ RUN cd / && \
     /bin/bash -c "source env/bin/activate" && \
     pip3 install --upgrade pip==9.0.1 && \
     pip3 install --upgrade virtualenv==15.1.0 && \
-    pip3 install wagon==0.6.3
+    pip3 install wagon==0.9
 
 WORKDIR /packaging
 

--- a/ubuntu_14_04_py3/cloudify-wagon-builder.sh
+++ b/ubuntu_14_04_py3/cloudify-wagon-builder.sh
@@ -20,9 +20,4 @@ else
     wagon create -r ${REQUIRMENTS_FILE} -v -f .
 fi
 
-echo "appending platform to wagon file name"
-OS_DIST=$(python -c 'import platform; print(platform.linux_distribution(full_distribution_name=False)[0])')
-OS_RELEASE=$(python -c 'import platform; print(platform.linux_distribution(full_distribution_name=False)[2])')
-ls /packaging/*.wgn | sed 'p;s/\.wgn/\-'${OS_DIST}'-'${OS_RELEASE}'.wgn/' | xargs -n2 mv
-
 cp -R * /workspace/build/


### PR DESCRIPTION
removed the rename since it will cause error installation since the name of the file must match the one in metadata , and bumped the wagon version