### PR TITLE
use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/centos_6_py2/Dockerfile
+++ b/centos_6_py2/Dockerfile
@@ -39,13 +39,13 @@ RUN cd /tmp && \
     python2.7 setup.py install && \
     curl https://bootstrap.pypa.io/get-pip.py | python2.7
 
-RUN pip install virtualenv==15.1.0
+RUN pip install --no-cache-dir virtualenv==15.1.0
 RUN cd / && \
     virtualenv env && \
     source env/bin/activate && \
-    pip install --upgrade pip==9.0.1 && \
-    pip install --upgrade virtualenv==15.1.0 && \
-    pip install wagon==0.11.0
+    pip install --no-cache-dir --upgrade pip==9.0.1 && \
+    pip install --no-cache-dir --upgrade virtualenv==15.1.0 && \
+    pip install --no-cache-dir wagon==0.11.0
 
 
 WORKDIR /packaging

--- a/centos_6_py3/Dockerfile
+++ b/centos_6_py3/Dockerfile
@@ -39,13 +39,13 @@ RUN cd /tmp && \
     python3.6 setup.py install && \
     curl https://bootstrap.pypa.io/get-pip.py | python3.6
 
-RUN pip3 install virtualenv==15.1.0
+RUN pip3 install --no-cache-dir virtualenv==15.1.0
 RUN cd / && \
     virtualenv env && \
     source env/bin/activate && \
-    pip3 install --upgrade pip==19.3.1 && \
-    pip3 install --upgrade virtualenv==15.1.0 && \
-    pip3 install wagon==0.11.0
+    pip3 install --no-cache-dir --upgrade pip==19.3.1 && \
+    pip3 install --no-cache-dir --upgrade virtualenv==15.1.0 && \
+    pip3 install --no-cache-dir wagon==0.11.0
 
 
 WORKDIR /packaging

--- a/centos_7_py2/Dockerfile
+++ b/centos_7_py2/Dockerfile
@@ -6,13 +6,13 @@ RUN yum -y install python-devel gcc openssl git libxslt-devel libxml2-devel open
 
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python
 
-RUN pip install virtualenv==15.1.0
+RUN pip install --no-cache-dir virtualenv==15.1.0
 RUN cd / && \
     virtualenv env && \
     source env/bin/activate && \
-    pip install --upgrade pip==9.0.1 && \
-    pip install --upgrade virtualenv==15.1.0 && \
-    pip install wagon==0.11.0
+    pip install --no-cache-dir --upgrade pip==9.0.1 && \
+    pip install --no-cache-dir --upgrade virtualenv==15.1.0 && \
+    pip install --no-cache-dir wagon==0.11.0
 
 
 WORKDIR /packaging

--- a/centos_7_py2py3/Dockerfile
+++ b/centos_7_py2py3/Dockerfile
@@ -9,8 +9,8 @@ RUN yum install -y python-virtualenv
 RUN cd / && \
     virtualenv py2env && \
     source py2env/bin/activate && \
-    pip install --upgrade pip==9.0.1 && \
-    pip install wagon==0.11.0
+    pip install --no-cache-dir --upgrade pip==9.0.1 && \
+    pip install --no-cache-dir wagon==0.11.0
 
 
 RUN yum -y install --enablerepo=updates python3 python3-devel
@@ -18,9 +18,9 @@ RUN yum -y install --enablerepo=updates python3 python3-devel
 RUN cd / && \
     python3 -m venv py3env && \
     source py3env/bin/activate && \
-    pip3 install --upgrade pip==19.3.1 && \
-    pip3 install --upgrade setuptools && \
-    pip3 install wagon==0.11.0
+    pip3 install --no-cache-dir --upgrade pip==19.3.1 && \
+    pip3 install --no-cache-dir --upgrade setuptools && \
+    pip3 install --no-cache-dir wagon==0.11.0
 
 
 WORKDIR /packaging

--- a/centos_7_py3/Dockerfile
+++ b/centos_7_py3/Dockerfile
@@ -10,13 +10,13 @@ RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
 
 RUN python3 get-pip.py
 
-RUN pip3 install virtualenv==15.1.0
+RUN pip3 install --no-cache-dir virtualenv==15.1.0
 RUN cd / && \
     virtualenv env && \
     source env/bin/activate && \
-    pip3 install --upgrade pip==19.3.1 && \
-    pip3 install --upgrade virtualenv==15.1.0 && \
-    pip3 install wagon==0.11.0
+    pip3 install --no-cache-dir --upgrade pip==19.3.1 && \
+    pip3 install --no-cache-dir --upgrade virtualenv==15.1.0 && \
+    pip3 install --no-cache-dir wagon==0.11.0
 
 
 WORKDIR /packaging

--- a/redhat_7_py2/Dockerfile
+++ b/redhat_7_py2/Dockerfile
@@ -14,13 +14,13 @@ RUN yum -y install python-devel gcc openssl git libxslt-devel libxml2-devel open
 
 RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python
 
-RUN pip install virtualenv==15.1.0
+RUN pip install --no-cache-dir virtualenv==15.1.0
 RUN cd / && \
     virtualenv env && \
     source env/bin/activate && \
-    pip install --upgrade pip==9.0.1 && \
-    pip install --upgrade virtualenv==15.1.0 && \
-    pip install wagon==0.11.0
+    pip install --no-cache-dir --upgrade pip==9.0.1 && \
+    pip install --no-cache-dir --upgrade virtualenv==15.1.0 && \
+    pip install --no-cache-dir wagon==0.11.0
 
 RUN subscription-manager unregister
 

--- a/redhat_7_py2py3/Dockerfile
+++ b/redhat_7_py2py3/Dockerfile
@@ -19,17 +19,17 @@ RUN yum install -y python-virtualenv
 RUN cd / && \
     virtualenv py2env && \
     source py2env/bin/activate && \
-    pip install --upgrade pip==9.0.1 && \
-    pip install wagon==0.11.0
+    pip install --no-cache-dir --upgrade pip==9.0.1 && \
+    pip install --no-cache-dir wagon==0.11.0
 
 RUN yum -y install python3 python3-devel
 
 RUN cd / && \
     python3 -m venv py3env && \
     source py3env/bin/activate && \
-    pip3 install --upgrade pip==19.3.1 && \
-    pip3 install --upgrade setuptools && \
-    pip3 install wagon==0.11.0
+    pip3 install --no-cache-dir --upgrade pip==19.3.1 && \
+    pip3 install --no-cache-dir --upgrade setuptools && \
+    pip3 install --no-cache-dir wagon==0.11.0
 
 RUN subscription-manager unregister
 

--- a/redhat_7_py3/Dockerfile
+++ b/redhat_7_py3/Dockerfile
@@ -20,13 +20,13 @@ RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
 
 RUN python3 get-pip.py
 
-RUN pip3 install virtualenv==15.1.0
+RUN pip3 install --no-cache-dir virtualenv==15.1.0
 RUN cd / && \
     virtualenv env && \
     source env/bin/activate && \
-    pip3 install --upgrade pip==19.3.1 && \
-    pip3 install --upgrade virtualenv==15.1.0 && \
-    pip3 install wagon==0.11.0
+    pip3 install --no-cache-dir --upgrade pip==19.3.1 && \
+    pip3 install --no-cache-dir --upgrade virtualenv==15.1.0 && \
+    pip3 install --no-cache-dir wagon==0.11.0
 
 
 RUN subscription-manager unregister

--- a/ubuntu_12_04_py2/Dockerfile
+++ b/ubuntu_12_04_py2/Dockerfile
@@ -13,13 +13,13 @@ RUN python get-pip.py
 
 RUN ln -s /usr/local/bin/pip /usr/bin/pip
 
-RUN pip install virtualenv==15.1.0
+RUN pip install --no-cache-dir virtualenv==15.1.0
 RUN cd / && \
     virtualenv env && \
     /bin/bash -c "source env/bin/activate" && \
-    pip install --upgrade pip==9.0.1 && \
-    pip install --upgrade virtualenv==15.1.0 && \
-    pip install wagon==0.11.0
+    pip install --no-cache-dir --upgrade pip==9.0.1 && \
+    pip install --no-cache-dir --upgrade virtualenv==15.1.0 && \
+    pip install --no-cache-dir wagon==0.11.0
 
 
 WORKDIR /packaging

--- a/ubuntu_12_04_py3/Dockerfile
+++ b/ubuntu_12_04_py3/Dockerfile
@@ -23,13 +23,13 @@ RUN cd /tmp && \
 
 RUN ln -s /usr/local/bin/pip3 /usr/bin/pip3
 
-RUN pip3 install virtualenv==15.1.0
+RUN pip3 install --no-cache-dir virtualenv==15.1.0
 RUN cd / && \
     virtualenv env && \
     /bin/bash -c "source env/bin/activate" && \
-    pip3 install --upgrade pip==19.3.1 && \
-    pip3 install --upgrade virtualenv==15.1.0 && \
-    pip3 install wagon==0.11.0
+    pip3 install --no-cache-dir --upgrade pip==19.3.1 && \
+    pip3 install --no-cache-dir --upgrade virtualenv==15.1.0 && \
+    pip3 install --no-cache-dir wagon==0.11.0
 
 
 WORKDIR /packaging

--- a/ubuntu_14_04_py2/Dockerfile
+++ b/ubuntu_14_04_py2/Dockerfile
@@ -12,13 +12,13 @@ RUN python get-pip.py
 
 RUN ln -s /usr/local/bin/pip /usr/bin/pip
 
-RUN pip install virtualenv==15.1.0
+RUN pip install --no-cache-dir virtualenv==15.1.0
 RUN cd / && \
     virtualenv env && \
     /bin/bash -c "source env/bin/activate" && \
-    pip install --upgrade pip==9.0.1 && \
-    pip install --upgrade virtualenv==15.1.0 && \
-    pip install wagon==0.11.0
+    pip install --no-cache-dir --upgrade pip==9.0.1 && \
+    pip install --no-cache-dir --upgrade virtualenv==15.1.0 && \
+    pip install --no-cache-dir wagon==0.11.0
 
 WORKDIR /packaging
 

--- a/ubuntu_14_04_py2py3/Dockerfile
+++ b/ubuntu_14_04_py2py3/Dockerfile
@@ -9,9 +9,9 @@ RUN apt-get -y install build-essential python-dev gcc openssl libffi-dev libssl-
 
 RUN cd / && \
     virtualenv py2env && \
-    py2env/bin/pip install --upgrade pip==9.0.1 && \
-    py2env/bin/pip install --upgrade virtualenv==15.1.0 && \
-    py2env/bin/pip install wagon==0.11.0
+    py2env/bin/pip install --no-cache-dir --upgrade pip==9.0.1 && \
+    py2env/bin/pip install --no-cache-dir --upgrade virtualenv==15.1.0 && \
+    py2env/bin/pip install --no-cache-dir wagon==0.11.0
 
 RUN cd /tmp && \
     wget https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tgz && \
@@ -24,9 +24,9 @@ RUN cd /tmp && \
 
 RUN cd / && \
     python3.6 -m venv py3env && \
-    py3env/bin/pip3 install --upgrade pip==19.3.1 setuptools && \
-    py3env/bin/pip3 install --upgrade virtualenv==15.1.0 && \
-    py3env/bin/pip3 install wagon==0.11.0
+    py3env/bin/pip3 install --no-cache-dir --upgrade pip==19.3.1 setuptools && \
+    py3env/bin/pip3 install --no-cache-dir --upgrade virtualenv==15.1.0 && \
+    py3env/bin/pip3 install --no-cache-dir wagon==0.11.0
 
 
 WORKDIR /packaging

--- a/ubuntu_14_04_py3/Dockerfile
+++ b/ubuntu_14_04_py3/Dockerfile
@@ -23,13 +23,13 @@ RUN cd /tmp && \
 
 RUN ln -s /usr/local/bin/pip3 /usr/bin/pip3
 
-RUN pip3 install virtualenv==15.1.0
+RUN pip3 install --no-cache-dir virtualenv==15.1.0
 RUN cd / && \
     virtualenv env && \
     /bin/bash -c "source env/bin/activate" && \
-    pip3 install --upgrade pip==19.3.1 && \
-    pip3 install --upgrade virtualenv==15.1.0 && \
-    pip3 install wagon==0.11.0
+    pip3 install --no-cache-dir --upgrade pip==19.3.1 && \
+    pip3 install --no-cache-dir --upgrade virtualenv==15.1.0 && \
+    pip3 install --no-cache-dir wagon==0.11.0
 
 WORKDIR /packaging
 

--- a/ubuntu_16_04_py2/Dockerfile
+++ b/ubuntu_16_04_py2/Dockerfile
@@ -8,9 +8,9 @@ RUN apt-get -y install build-essential python-dev gcc openssl libffi-dev libssl-
 
 RUN cd / && \
     virtualenv env && \
-    env/bin/pip install --upgrade pip==9.0.1 && \
-    env/bin/pip install --upgrade virtualenv==15.1.0 && \
-    env/bin/pip install wagon==0.11.0
+    env/bin/pip install --no-cache-dir --upgrade pip==9.0.1 && \
+    env/bin/pip install --no-cache-dir --upgrade virtualenv==15.1.0 && \
+    env/bin/pip install --no-cache-dir wagon==0.11.0
 
 WORKDIR /packaging
 

--- a/ubuntu_16_04_py2py3/Dockerfile
+++ b/ubuntu_16_04_py2py3/Dockerfile
@@ -9,9 +9,9 @@ RUN apt-get -y install build-essential python-dev gcc openssl libffi-dev libssl-
 
 RUN cd / && \
     virtualenv py2env && \
-    py2env/bin/pip install --upgrade pip==9.0.1 && \
-    py2env/bin/pip install --upgrade virtualenv==15.1.0 && \
-    py2env/bin/pip install wagon==0.11.0
+    py2env/bin/pip install --no-cache-dir --upgrade pip==9.0.1 && \
+    py2env/bin/pip install --no-cache-dir --upgrade virtualenv==15.1.0 && \
+    py2env/bin/pip install --no-cache-dir wagon==0.11.0
 
 RUN cd /tmp && \
     wget https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tgz && \
@@ -24,9 +24,9 @@ RUN cd /tmp && \
 
 RUN cd / && \
     python3.6 -m venv py3env && \
-    py3env/bin/pip3 install --upgrade pip==19.3.1 setuptools && \
-    py3env/bin/pip3 install --upgrade virtualenv==15.1.0 && \
-    py3env/bin/pip3 install wagon==0.11.0
+    py3env/bin/pip3 install --no-cache-dir --upgrade pip==19.3.1 setuptools && \
+    py3env/bin/pip3 install --no-cache-dir --upgrade virtualenv==15.1.0 && \
+    py3env/bin/pip3 install --no-cache-dir wagon==0.11.0
 
 
 WORKDIR /packaging

--- a/ubuntu_16_04_py3/Dockerfile
+++ b/ubuntu_16_04_py3/Dockerfile
@@ -16,9 +16,9 @@ RUN cd /tmp && \
 
 RUN cd / && \
     python3.6 -m venv env && \
-    env/bin/pip3 install --upgrade pip==19.3.1 setuptools && \
-    env/bin/pip3 install --upgrade virtualenv==15.1.0 && \
-    env/bin/pip3 install wagon==0.11.0
+    env/bin/pip3 install --no-cache-dir --upgrade pip==19.3.1 setuptools && \
+    env/bin/pip3 install --no-cache-dir --upgrade virtualenv==15.1.0 && \
+    env/bin/pip3 install --no-cache-dir wagon==0.11.0
 
 WORKDIR /packaging
 

--- a/ubuntu_18_04_py2/Dockerfile
+++ b/ubuntu_18_04_py2/Dockerfile
@@ -8,9 +8,9 @@ RUN apt-get -y install build-essential python-dev gcc openssl libffi-dev libssl-
 
 RUN cd / && \
     virtualenv env && \
-    env/bin/pip install --upgrade pip==9.0.1 && \
-    env/bin/pip install --upgrade virtualenv==15.1.0 && \
-    env/bin/pip install wagon==0.11.0
+    env/bin/pip install --no-cache-dir --upgrade pip==9.0.1 && \
+    env/bin/pip install --no-cache-dir --upgrade virtualenv==15.1.0 && \
+    env/bin/pip install --no-cache-dir wagon==0.11.0
 
 WORKDIR /packaging
 

--- a/ubuntu_18_04_py2py3/Dockerfile
+++ b/ubuntu_18_04_py2py3/Dockerfile
@@ -8,17 +8,17 @@ RUN apt-get -y install build-essential python-dev gcc openssl libffi-dev libssl-
 
 RUN cd / && \
     virtualenv py2env && \
-    py2env/bin/pip install --upgrade pip==9.0.1 && \
-    py2env/bin/pip install --upgrade virtualenv==15.1.0 && \
-    py2env/bin/pip install wagon==0.11.0
+    py2env/bin/pip install --no-cache-dir --upgrade pip==9.0.1 && \
+    py2env/bin/pip install --no-cache-dir --upgrade virtualenv==15.1.0 && \
+    py2env/bin/pip install --no-cache-dir wagon==0.11.0
 
 RUN  apt-get install -y python3-venv
 
 RUN cd / && \
     python3 -m venv py3env && \
-    py3env/bin/pip3 install --upgrade pip==19.3.1 setuptools && \
-    py3env/bin/pip3 install --upgrade virtualenv==15.1.0 && \
-    py3env/bin/pip3 install wagon==0.11.0
+    py3env/bin/pip3 install --no-cache-dir --upgrade pip==19.3.1 setuptools && \
+    py3env/bin/pip3 install --no-cache-dir --upgrade virtualenv==15.1.0 && \
+    py3env/bin/pip3 install --no-cache-dir wagon==0.11.0
 
 
 WORKDIR /packaging

--- a/ubuntu_18_04_py3/Dockerfile
+++ b/ubuntu_18_04_py3/Dockerfile
@@ -10,9 +10,9 @@ RUN  apt-get install -y python3-venv
 
 RUN cd / && \
     python3 -m venv env && \
-    env/bin/pip3 install --upgrade pip==19.3.1 setuptools && \
-    env/bin/pip3 install --upgrade virtualenv==15.1.0 && \
-    env/bin/pip3 install wagon==0.11.0
+    env/bin/pip3 install --no-cache-dir --upgrade pip==19.3.1 setuptools && \
+    env/bin/pip3 install --no-cache-dir --upgrade virtualenv==15.1.0 && \
+    env/bin/pip3 install --no-cache-dir wagon==0.11.0
 
 WORKDIR /packaging
 


### PR DESCRIPTION
using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>