### PR TITLE
fix-pip-py2-links

### DIFF
--- a/centos_7_py2/Dockerfile
+++ b/centos_7_py2/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Cosmo (hello@cloudify.co)
 
 RUN yum -y install python-devel gcc openssl git libxslt-devel libxml2-devel openldap-devel libffi-devel openssl-devel libvirt-devel python-netaddr
 
-RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python
+RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/pip/2.7/get-pip.py | python
 
 RUN pip install virtualenv==15.1.0
 RUN cd / && \

--- a/redhat_7_py2/Dockerfile
+++ b/redhat_7_py2/Dockerfile
@@ -12,7 +12,7 @@ RUN yum-config-manager --enable rhel-server-rhscl-7-rpms
 
 RUN yum -y install python-devel gcc openssl git libxslt-devel libxml2-devel openldap-devel libffi-devel openssl-devel libvirt-devel python-netaddr
 
-RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/get-pip.py | python
+RUN curl --silent --show-error --retry 5 https://bootstrap.pypa.io/pip/2.7/get-pip.py | python
 
 RUN pip install virtualenv==15.1.0
 RUN cd / && \

--- a/ubuntu_12_04_py2/Dockerfile
+++ b/ubuntu_12_04_py2/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update
 RUN apt-get -y install build-essential python-dev gcc openssl libffi-dev libssl-dev libvirt-dev python-netaddr curl git
 
 
-RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
+RUN curl "https://bootstrap.pypa.io/pip/2.7/get-pip.py" -o "get-pip.py"
 
 RUN python get-pip.py
 

--- a/ubuntu_14_04_py2/Dockerfile
+++ b/ubuntu_14_04_py2/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update
 
 RUN apt-get -y install build-essential python-dev gcc openssl libffi-dev libssl-dev libvirt-dev python-netaddr curl git
 
-RUN curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
+RUN curl "https://bootstrap.pypa.io/pip/2.7/get-pip.py" -o "get-pip.py"
 
 RUN python get-pip.py
 


### PR DESCRIPTION
use https://bootstrap.pypa.io/pip/2.7/get-pip.py , 
as the old link will reference the latest python 