### PR TITLE
possible-fix-ubuntu

### DIFF
--- a/ubuntu_12_04_py2/Dockerfile
+++ b/ubuntu_12_04_py2/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get -y install build-essential python-dev gcc openssl libffi-dev libssl-
 
 RUN curl "https://bootstrap.pypa.io/pip/2.7/get-pip.py" -o "get-pip.py"
 
-RUN python get-pip.py
+RUN python get-pip.py --trusted-host pypi.org --trusted-host files.pythonhosted.org --trusted-host pypi.python.org
 
 RUN ln -s /usr/local/bin/pip /usr/bin/pip
 

--- a/ubuntu_14_04_py2/Dockerfile
+++ b/ubuntu_14_04_py2/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get -y install build-essential python-dev gcc openssl libffi-dev libssl-
 
 RUN curl "https://bootstrap.pypa.io/pip/2.7/get-pip.py" -o "get-pip.py"
 
-RUN python get-pip.py
+RUN python get-pip.py --trusted-host pypi.org --trusted-host files.pythonhosted.org --trusted-host pypi.python.org
 
 RUN ln -s /usr/local/bin/pip /usr/bin/pip
 

--- a/ubuntu_16_04_py2/Dockerfile
+++ b/ubuntu_16_04_py2/Dockerfile
@@ -4,10 +4,11 @@ MAINTAINER Cosmo (hello@cloudify.co)
 
 RUN apt-get update
 
-RUN apt-get -y install build-essential python-dev gcc openssl libffi-dev libssl-dev libvirt-dev python-netaddr python-pip python-virtualenv git
+RUN apt-get -y install build-essential python-dev gcc openssl libffi-dev libssl-dev libvirt-dev python-netaddr python-pip python-virtualenv git curl
 
 ENV LANG en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
+RUN dpkg-reconfigure locales
 
 # patching pip
 RUN curl --silent --show-error --retry 5 http://pylegacy.org/hub/get-pip-pyopenssl.py | python


### PR DESCRIPTION
so on ubuntu 14 and 16 , 

ubuntu 14 
```
Could not fetch URL https://pypi.org/simple/pip/: There was a problem confirming the ssl certificate: HTTPSConnectionPool(host='pypi.org', port=443): Max retries exceeded with url: /simple/pip/ (Caused by SSLError(CertificateError("hostname 'pypi.org' doesn't match either of 'www.python.org', '*.python.org', 'docs.python.org', 'downloads.python.org', 'pypi.python.org'",),)) - skipping
 The command '/bin/sh -c python get-pip.py' returned a non-zero code: 1
```
and ubuntu 16
```
locale.Error: unsupported locale setting
```
