### PR TITLE
fix-rhel8-subscription

### DIFF
--- a/redhat_8_py3/Dockerfile
+++ b/redhat_8_py3/Dockerfile
@@ -6,6 +6,8 @@ ARG USERNAME
 
 ARG PASSWORD
 
+ENV SMDEV_CONTAINER_OFF=1
+
 RUN subscription-manager register --username "$USERNAME" --password "$PASSWORD" --auto-attach
 
 RUN yum -y install yum-utils


### PR DESCRIPTION
seems RHEL8 subscription is not working anymore [ might be related to their recent changes ] 
but this PR is an attempt to address 

```
Step 5/23 : RUN subscription-manager register --username "$USERNAME" --password "$PASSWORD" --auto-attach
 ---> Running in 67a168618917
subscription-manager is disabled when running inside a container. Please refer to your host system for subscription management.

```