### PR TITLE
fix-rhel8-subscription

### DIFF
--- a/redhat_8_py3/Dockerfile
+++ b/redhat_8_py3/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi:8.6
 
 MAINTAINER Cosmo (hello@cloudify.co)
 


### PR DESCRIPTION
pinning the version to 8.6 seems to work , as the previous fix didn't actually fix anything